### PR TITLE
chore(deps): update github/codeql-action action to v3.28.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,7 @@ jobs:
 
             # Initializes the CodeQL tools for scanning.
             - name: "Initialize CodeQL"
-              uses: "github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae" # v3.27.9
+              uses: "github/codeql-action/init@dd196fa9ce80b6bacc74ca1c32bd5b0ba22efca7" # v3.28.3
               with:
                   languages: "${{ matrix.language }}"
                   # If you wish to specify custom queries, you can do so here or in a config file.
@@ -62,7 +62,7 @@ jobs:
             # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
             # If this step fails, then you should remove it and run the build manually (see below)
             - name: "Autobuild"
-              uses: "github/codeql-action/autobuild@df409f7d9260372bd5f19e5b04e83cb3c43714ae" # v3.27.9
+              uses: "github/codeql-action/autobuild@dd196fa9ce80b6bacc74ca1c32bd5b0ba22efca7" # v3.28.3
 
             # ℹ️ Command-line programs to run using the OS shell.
             # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -75,6 +75,6 @@ jobs:
             #   ./location_of_script_within_repo/buildscript.sh
 
             - name: "Perform CodeQL Analysis"
-              uses: "github/codeql-action/analyze@df409f7d9260372bd5f19e5b04e83cb3c43714ae" # v3.27.9
+              uses: "github/codeql-action/analyze@dd196fa9ce80b6bacc74ca1c32bd5b0ba22efca7" # v3.28.3
               with:
                   category: "/language:${{matrix.language}}"

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -73,6 +73,6 @@ jobs:
 
             # Upload the results to GitHub's code scanning dashboard.
             - name: "Upload to code-scanning"
-              uses: "github/codeql-action/upload-sarif@df409f7d9260372bd5f19e5b04e83cb3c43714ae" # v3.27.9
+              uses: "github/codeql-action/upload-sarif@dd196fa9ce80b6bacc74ca1c32bd5b0ba22efca7" # v3.28.3
               with:
                   sarif_file: "results.sarif"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations for CodeQL and Scorecards
	- Upgraded CodeQL action versions from 3.27.9 to 3.28.3
	- Updated SARIF file upload action version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->