### PR TITLE
ci(lint): fix yaml-lint violations and bump lint pin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,5 @@
 name: "CodeQL"
-on:
+on: # yamllint disable-line rule:truthy
     push:
         branches: ["main"]
     pull_request:
@@ -15,5 +15,5 @@ jobs:
             contents: "read"
         uses: "anolilab/workflows/.github/workflows/codeql.yml@20b8733e71ebbb165d54fe8cede47e225985a58a" # v15.3.1+
         with:
-            languages: '["javascript-typescript"]'
-            branches: '["main"]'
+            languages: "[\"javascript-typescript\"]"
+            branches: "[\"main\"]"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,5 +1,5 @@
 name: "Dependency review"
-on:
+on: # yamllint disable-line rule:truthy
     pull_request:
         branches: ["main"]
 permissions: {}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: "Lint"
-on:
+on: # yamllint disable-line rule:truthy
     pull_request:
         branches: ["main"]
 permissions: {}
@@ -8,7 +8,7 @@ jobs:
         permissions:
             contents: "read"
             pull-requests: "read"
-        uses: "anolilab/workflows/.github/workflows/lint.yml@20b8733e71ebbb165d54fe8cede47e225985a58a" # v15.3.1+
+        uses: "anolilab/workflows/.github/workflows/lint.yml@1dc687e78887af5536dbd0877054fc1c56c5575b" # v15.3.1+
         with:
             lint_eslint: false
             lint_types: false

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,6 +1,6 @@
 name: "Scorecards supply-chain security"
-on:
-    branch_protection_rule:
+on: # yamllint disable-line rule:truthy
+    branch_protection_rule: ~
     schedule:
         - cron: "37 14 * * 6"
     push:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,5 +1,5 @@
 name: "Zizmor"
-on:
+on: # yamllint disable-line rule:truthy
     push:
         branches: ["main"]
     pull_request:


### PR DESCRIPTION
Propagation of lint fixes from anolilab/javascript-style-guide#1028.

## Summary
- Add `# yamllint disable-line rule:truthy` to workflow `on:` keys
- Convert single-quoted JSON arrays to double-quoted (codeql.yml, test.yml)
- Set scorecards.yml `branch_protection_rule:` to `~` (empty-values)
- Bump shared lint workflow pin to `1dc687e` (catalog: stash workaround)
- Quote \`\${files}\` expansion in shell run blocks (shellcheck SC2086)


## Test plan
- [ ] Lint workflow passes (yaml + github workflows)